### PR TITLE
chore: update deprecated provideServerRoutesConfig to provideServerRouting

### DIFF
--- a/frontend/windows-store-client/src/app/app.config.server.ts
+++ b/frontend/windows-store-client/src/app/app.config.server.ts
@@ -1,13 +1,13 @@
 import { mergeApplicationConfig, ApplicationConfig } from '@angular/core';
 import { provideServerRendering } from '@angular/platform-server';
-import { provideServerRoutesConfig } from '@angular/ssr';
+import { provideServerRouting } from '@angular/ssr';
 import { appConfig } from './app.config';
 import { serverRoutes } from './app.routes.server';
 
 const serverConfig: ApplicationConfig = {
   providers: [
     provideServerRendering(),
-    provideServerRoutesConfig(serverRoutes)
+    provideServerRouting(serverRoutes)
   ]
 };
 


### PR DESCRIPTION
provideServerRoutesConfig will be removed in Angular version 20. Updated configuration to ensure compatibility with future releases.